### PR TITLE
Add jupyter notebook and binder button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # bbw
 [![PyPI version](https://badge.fury.io/py/bbw.svg)](https://badge.fury.io/py/bbw)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/UB-Mannheim/bbw/master?filepath=bbw.ipynb)
 
 * Annotates tabular data with the entities, types and properties in [Wikidata](https://www.wikidata.org).
 * Easy to use: bbw.annotate().

--- a/bbw.ipynb
+++ b/bbw.ipynb
@@ -1,0 +1,516 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bbw import bbw\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>0</th>\n",
+       "      <th>1</th>\n",
+       "      <th>2</th>\n",
+       "      <th>3</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>col0</td>\n",
+       "      <td>col1</td>\n",
+       "      <td>col2</td>\n",
+       "      <td>col3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Mannheim</td>\n",
+       "      <td>Rhine</td>\n",
+       "      <td>97</td>\n",
+       "      <td>Baden-Württemberg</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Edingburgh</td>\n",
+       "      <td>River Forth</td>\n",
+       "      <td>47</td>\n",
+       "      <td>City of Edingburgh</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "            0            1     2                   3\n",
+       "0        col0         col1  col2                col3\n",
+       "1    Mannheim        Rhine    97   Baden-Württemberg\n",
+       "2  Edingburgh  River Forth    47  City of Edingburgh"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data = [\n",
+    "    ['col0', 'col1', 'col2', 'col3'],\n",
+    "    ['Mannheim','Rhine', '97', 'Baden-Württemberg'],\n",
+    "    ['Edingburgh','River Forth', '47', 'City of Edingburgh']\n",
+    "]\n",
+    "df = pd.DataFrame(data)\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "[web_table, url_table, label_table, cpa, cea, cta] = bbw.annotate(df, \"output.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>file</th>\n",
+       "      <th>column0</th>\n",
+       "      <th>column</th>\n",
+       "      <th>property</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>output</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>http://www.wikidata.org/prop/direct/P206</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>output</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2</td>\n",
+       "      <td>http://www.wikidata.org/prop/direct/P2044</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>output</td>\n",
+       "      <td>0</td>\n",
+       "      <td>3</td>\n",
+       "      <td>http://www.wikidata.org/prop/direct/P131</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     file  column0  column                                   property\n",
+       "0  output        0       1   http://www.wikidata.org/prop/direct/P206\n",
+       "1  output        0       2  http://www.wikidata.org/prop/direct/P2044\n",
+       "2  output        0       3   http://www.wikidata.org/prop/direct/P131"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cpa"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>file</th>\n",
+       "      <th>column</th>\n",
+       "      <th>itemType</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>output</td>\n",
+       "      <td>0</td>\n",
+       "      <td>http://www.wikidata.org/entity/Q515</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>output</td>\n",
+       "      <td>1</td>\n",
+       "      <td>http://www.wikidata.org/entity/Q4022</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>output</td>\n",
+       "      <td>3</td>\n",
+       "      <td>http://www.wikidata.org/entity/Q1799794</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     file  column                                 itemType\n",
+       "0  output       0      http://www.wikidata.org/entity/Q515\n",
+       "1  output       1     http://www.wikidata.org/entity/Q4022\n",
+       "2  output       3  http://www.wikidata.org/entity/Q1799794"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cta"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>file</th>\n",
+       "      <th>row</th>\n",
+       "      <th>column</th>\n",
+       "      <th>item</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>output</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>http://www.wikidata.org/entity/Q2119</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>output</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>http://www.wikidata.org/entity/Q584</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>output</td>\n",
+       "      <td>1</td>\n",
+       "      <td>3</td>\n",
+       "      <td>http://www.wikidata.org/entity/Q985</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>output</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0</td>\n",
+       "      <td>http://www.wikidata.org/entity/Q23436</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>output</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>http://www.wikidata.org/entity/Q2421</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>output</td>\n",
+       "      <td>2</td>\n",
+       "      <td>3</td>\n",
+       "      <td>http://www.wikidata.org/entity/Q2379199</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     file  row  column                                     item\n",
+       "0  output    1       0     http://www.wikidata.org/entity/Q2119\n",
+       "1  output    1       1      http://www.wikidata.org/entity/Q584\n",
+       "2  output    1       3      http://www.wikidata.org/entity/Q985\n",
+       "3  output    2       0    http://www.wikidata.org/entity/Q23436\n",
+       "4  output    2       1     http://www.wikidata.org/entity/Q2421\n",
+       "5  output    2       3  http://www.wikidata.org/entity/Q2379199"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cea"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>col0</th>\n",
+       "      <th>col1</th>\n",
+       "      <th>col2</th>\n",
+       "      <th>col3</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Mannheim</td>\n",
+       "      <td>Rhine</td>\n",
+       "      <td></td>\n",
+       "      <td>Baden-Württemberg</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Edinburgh</td>\n",
+       "      <td>River Forth</td>\n",
+       "      <td></td>\n",
+       "      <td>City of Edinburgh</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>property</th>\n",
+       "      <td></td>\n",
+       "      <td>located in or next to body of water</td>\n",
+       "      <td>elevation above sea level</td>\n",
+       "      <td>located in the administrative territorial entity</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>type</th>\n",
+       "      <td>city</td>\n",
+       "      <td>river</td>\n",
+       "      <td></td>\n",
+       "      <td>administrative territorial entity of a specifi...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "0              col0                                 col1  \\\n",
+       "1          Mannheim                                Rhine   \n",
+       "2         Edinburgh                          River Forth   \n",
+       "property             located in or next to body of water   \n",
+       "type           city                                river   \n",
+       "\n",
+       "0                              col2  \\\n",
+       "1                                     \n",
+       "2                                     \n",
+       "property  elevation above sea level   \n",
+       "type                                  \n",
+       "\n",
+       "0                                                      col3  \n",
+       "1                                         Baden-Württemberg  \n",
+       "2                                         City of Edinburgh  \n",
+       "property   located in the administrative territorial entity  \n",
+       "type      administrative territorial entity of a specifi...  "
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "label_table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "error searx IR\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Use searx to get the bestname for a string with mistakes\n",
+    "bbw.get_searx_bestname('Monnhem')\n",
+    "bbw.get_searx_bestname('dingbur')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## GUI\n",
+    "We can starte the streamlit python app within this jupyter notebook. If you do this locally then it should be possible to navigabte with your browser to that page. Hower, if you run this juptyter notebook within binder, then accessing it from external seems not to work."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[0m\r\n",
+      "\u001b[34m\u001b[1m  You can now view your Streamlit app in your browser.\u001b[0m\r\n",
+      "\u001b[0m\r\n",
+      "\u001b[34m  Network URL: \u001b[0m\u001b[1mhttp://10.2.1.202:8501\u001b[0m\r\n",
+      "\u001b[34m  External URL: \u001b[0m\u001b[1mhttp://51.68.114.184:8501\u001b[0m\r\n",
+      "\u001b[0m\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!streamlit run bbw_gui.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+sed -i 's|http://localhost:80/|https://searx.ir|g' bbw/bbw.py


### PR DESCRIPTION
This will bring the functionalities into jupyter notebook which can be started within the browser with the help of binder.

Try it out: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/UB-Mannheim/bbw/binderize?filepath=bbw.ipynb)

For demonstration purposes we use a public available SearX interface. This will only work for a couple of requests.